### PR TITLE
Configure allowed plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,10 @@
         "branch-alias": {
             "dev-master": "5.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
As stated in https://getcomposer.org/doc/06-config.md#allow-plugins
Composer 2.2 will disallow any plugins unless configured.