### PR TITLE
Doctrine CS 10, Slevomat CS 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.phpunit.result.cache
 composer.lock
 phpcs.log
 vendor

--- a/README.md
+++ b/README.md
@@ -64,6 +64,5 @@ Docker
 
 Used Code Styles
 ================
-- Symfony2 https://github.com/djoos/Symfony2-coding-standard
 - Slevomat https://github.com/slevomat/coding-standard
-
+- Doctrine https://github.com/doctrine/coding-standard

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     },
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-        "doctrine/coding-standard": "^9.0",
-        "slevomat/coding-standard": "^7.0",
-        "squizlabs/php_codesniffer": "^3.4"
+        "doctrine/coding-standard": "^10.0",
+        "slevomat/coding-standard": "^8.4",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.5"
     },
     "scripts": {
         "tests": [
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0-dev"
+            "dev-master": "6.0-dev"
         }
     },
     "config": {


### PR DESCRIPTION
This PR updated the Doctrine and Slevomat standards to their current major releases. Especially the Slevomat standard should be updated on codebases that use native intersection types.

Since both standards have been bumped to a new major, I suggest to do so for this standard as well, releasing this change as version 6.0.0.